### PR TITLE
fix: 데이터 도구 페이지 타이틀 싱크 맞추기 페이지 제목 패딩값 동일화

### DIFF
--- a/3-application/pages/app_bootstrap.py
+++ b/3-application/pages/app_bootstrap.py
@@ -20,6 +20,11 @@ def _hide_builtin_nav():
 
 
 def render_sidebar():
+    st.markdown("""
+    <style>
+      .block-container { padding-top: 1.25rem !important; }
+    </style>
+    """, unsafe_allow_html=True)
     # 전체 css 로드
     apply_inline_css()
     # 기본 네비게이션 숨김


### PR DESCRIPTION
데이터도구 #57
Issues#57 해결